### PR TITLE
Update Asset-Submission.yaml to add asset-submission

### DIFF
--- a/.github/ISSUE_TEMPLATE/Asset-Submission.yaml
+++ b/.github/ISSUE_TEMPLATE/Asset-Submission.yaml
@@ -1,6 +1,6 @@
 name: Asset contribution
 description: Submit an asset to include with MCprep
-labels: ["enhancement"]
+labels: ["enhancement", "asset-submission"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
Moving forward, using this label to apply to asset submissions to make it easier to identify, and to potentially identify community members to review.