### PR TITLE
Added 'rc' as an ignore filter

### DIFF
--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -1286,8 +1286,10 @@ def skip_tag_function(self, tag):
 	# ---- write any custom code above, return true to disallow version --- #
 	
 	# Ignore release candidates
-	if 'rc' in tag.lower():
-		return True
+	skip_if_present = ['rc', 'alpha', 'beta']
+	for skip_name in skip_if_present:
+		if skip_name in tag.lower():
+			return True
 
 	if self.include_branches:
 		for branch in self.include_branch_list:

--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -1284,6 +1284,10 @@ def skip_tag_function(self, tag):
 	# if 'beta' in tag.lower():
 	# 	return True
 	# ---- write any custom code above, return true to disallow version --- #
+	
+	# Ignore release candidates
+	if 'rc' in tag.lower():
+		return True
 
 	if self.include_branches:
 		for branch in self.include_branch_list:


### PR DESCRIPTION
MCprep is moving towards a new 5-stage development cycle (Stage 0 to 4), where Stage 4 involves creating release candidates for testing and feedback purposes. Release candiates use the format "#.#.#.#-rc-#" for tags, to make them distinct from regular releases.

Thus, the addon updater should ignore these release candidates, as stability is not guranteed.