### PR TITLE
Fix animated textures updater

### DIFF
--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -1284,11 +1284,11 @@ def skip_tag_function(self, tag):
 	# if 'beta' in tag.lower():
 	# 	return True
 	# ---- write any custom code above, return true to disallow version --- #
-	
+
 	# Ignore release candidates
 	skip_if_present = ['rc', 'alpha', 'beta']
 	for skip_name in skip_if_present:
-		if skip_name in tag.lower():
+		if skip_name in tag.get("tag_name", "").lower():
 			return True
 
 	if self.include_branches:

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -246,13 +246,13 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 
 			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 				options = generate.PrepOptions(
-					passes, 
-					self.useReflections, 
-					self.usePrincipledShader, 
-					self.makeSolid, 
-					generate.PackFormat[self.packFormat.upper()], 
-					self.useEmission, 
-					False # This is for an option set in matprep_cycles
+					passes,
+					self.useReflections,
+					self.usePrincipledShader,
+					self.makeSolid,
+					generate.PackFormat[self.packFormat.upper()],
+					self.useEmission,
+					False  # This is for an option set in matprep_cycles
 				)
 				res = generate.matprep_cycles(
 					mat=mat,
@@ -270,7 +270,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 				sequences.animate_single_material(
 					mat,
 					context.scene.render.engine,
-					export_location="original")
+					export_location=sequences.ExportLocation.ORIGINAL)
 
 		# Sync materials.
 		if self.syncMaterials is True:
@@ -389,16 +389,16 @@ class MCPREP_OT_swap_texture_pack(
 	bl_options = {'REGISTER', 'UNDO'}
 
 	filter_glob: bpy.props.StringProperty(
-		default="", 
+		default="",
 		options={"HIDDEN"})
 	use_filter_folder = True
 	fileselectparams = "use_filter_blender"
 	filepath: bpy.props.StringProperty(subtype="DIR_PATH")
 	filter_image: bpy.props.BoolProperty(
-		default=True, 
+		default=True,
 		options={"HIDDEN", "SKIP_SAVE"})
 	filter_folder: bpy.props.BoolProperty(
-		default=True, 
+		default=True,
 		options={"HIDDEN", "SKIP_SAVE"})
 	prepMaterials: bpy.props.BoolProperty(
 		name="Prep materials",
@@ -406,7 +406,7 @@ class MCPREP_OT_swap_texture_pack(
 		default=False,
 	)
 	skipUsage: bpy.props.BoolProperty(
-		default=False, 
+		default=False,
 		options={"HIDDEN"})
 
 	@classmethod
@@ -437,7 +437,7 @@ class MCPREP_OT_swap_texture_pack(
 			col.prop(self, "syncMaterials")
 			col.prop(self, "improveUiSettings")
 			col.prop(self, "combineMaterials")
-	
+
 	track_function = "texture_pack"
 	track_param = None
 	track_exporter = None
@@ -484,7 +484,7 @@ class MCPREP_OT_swap_texture_pack(
 				sequences.animate_single_material(
 					mat,
 					context.scene.render.engine,
-					export_location="original")
+					export_location=sequences.ExportLocation.ORIGINAL)
 			# may be a double call if was animated tex
 			generate.set_saturation_material(mat)
 
@@ -634,7 +634,9 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 
 		if self.animateTextures:
 			sequences.animate_single_material(
-				mat, context.scene.render.engine, export_location=sequences.ExportLocation["original"])
+				mat,
+				context.scene.render.engine,
+				export_location=sequences.ExportLocation.ORIGINAL)
 
 		return success, None
 


### PR DESCRIPTION
Fixed the reference which was causing a failure, and improve the tests to more directly check for an animated sequence node output.

All tests passing:

```
-------------------------------------------------------------------------------
bversion   	ran_tests	ran	skips	failed	errors
-------------------------------------------------------------------------------
(3.6.2)   	all_tests	35	2	0	No errors
(4.0.0)   	all_tests	35	2	0	No errors
(3.5.1)   	all_tests	35	2	0	No errors
(3.4.0)   	all_tests	35	2	0	No errors
(3.3.1)   	all_tests	35	2	0	No errors
(3.2.1)   	all_tests	35	2	0	No errors
(3.1.0)   	all_tests	35	2	0	No errors
(3.0.0)   	all_tests	35	2	0	No errors
(2.93.0)   	all_tests	35	2	0	No errors
(2.90.1)   	all_tests	35	2	0	No errors
(2.80.75)   	all_tests	34	3	0	No errors
tests took 204s to run
```