### PR TITLE
Added disclaimer in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MCprep is an addon dedicated to speeding up the workflow of Minecraft animators 
 
 [![Install MCprep](/visuals/mcprep_download.png)](https://theduckcow.com/dev/blender/mcprep-download/)
 
-*By downloading and installing, you agree to the following [privacy policy](https://theduckcow.com/privacy-policy).* **[Watch this video](https://www.youtube.com/watch?v=i6Ne07-eIyI) on how to install if running into troubles.**
+*By downloading and installing, you agree to the following [privacy policy](https://theduckcow.com/privacy-policy). In addition, it is assumed you own a valid copy of Minecraft.* **[Watch this video](https://www.youtube.com/watch?v=i6Ne07-eIyI) on how to install if running into troubles.**
 
 
 It should remain a zip folder. In blender, go to preferences, then the addons tab, and at the bottom of the window install from file. Select the .zip file. **NOTE:** _Blender may not automatically enable the addon. If the MCprep addon is not already shown in the window after installing, search for it at left and then ensure the check box is enabled._ **Save user preferences** to keep it enabled next time blender opens.


### PR DESCRIPTION
This adds a disclaimer to the README that it is assumed the user owns a valid copy of Minecraft, in response to the EULA changes.