### PR TITLE
Ensure tracker files never remain after tests or during prod builds

### DIFF
--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -33,7 +33,7 @@ TIMEOUT = 60
 # If we see any of these IDs in local json files, still treat as a re-install
 # but replace the ID with the new one received.
 # See example: https://github.com/Moo-Ack-Productions/MCprep/issues/491
-INVALID_IDS = ["-Nb8TgbvAoxHrnEe1WFy"]
+INVALID_IDS = ["-Nb8TgbvAoxHrnEe1WFy", "-Ng7l5P8EuGMBycEwWPQ"]
 
 
 # remaining, wrap in safe-importing

--- a/push_latest.sh
+++ b/push_latest.sh
@@ -29,6 +29,7 @@ echo ""
 echo "Current status (should be empty!)"
 git status
 
+
 echo "Running tests"
 python run_tests.py -a
 if [ $? -eq 0 ]; then
@@ -68,6 +69,9 @@ fi
 # Validate and build the release.
 # -----------------------------------------------------------------------------
 
+echo "Force remove trcaker files, in case they are left over"
+rm MCprep_addon/mcprep_addon_tracker.json
+rm mcprep_addon_trackerid.json
 
 echo "Building prod addon..."
 bpy-addon-build # No --during-build dev to make it prod.

--- a/run_tests.py
+++ b/run_tests.py
@@ -107,6 +107,9 @@ def main():
 
     t1 = time.time()
 
+    # Especially ensure tracker files are removed after tests complete.
+    remove_tracker_files()
+
     output_results()
     round_s = round(t1 - t0)
     exit_code = 1 if any_failures else 0
@@ -181,6 +184,25 @@ def output_results():
             print(tabline)
             if idx == 0:
                 print(SPACER)
+
+
+def remove_tracker_files():
+    """Ensure local tracker files are NEVER left around after tests."""
+    git_dir = os.path.dirname(__file__)
+    jfile = "mcprep_addon_tracker.json"
+    jpath = os.path.join(git_dir, jfile)
+    par_jfile = "mcprep_addon_trackerid.json"
+    par_jpath = os.path.join(git_dir, par_jfile)
+
+    has_jpath = os.path.isfile(jpath)
+    has_par_jpath = os.path.isfile(par_jpath)
+
+    if has_jpath:
+        print("Removing: ", jpath)
+        os.remove(jpath)
+    if has_par_jpath:
+        print("Removing: ", par_jpath)
+        os.remove(par_jpath)
 
 
 if __name__ == "__main__":

--- a/run_tests.py
+++ b/run_tests.py
@@ -190,7 +190,7 @@ def remove_tracker_files():
     """Ensure local tracker files are NEVER left around after tests."""
     git_dir = os.path.dirname(__file__)
     jfile = "mcprep_addon_tracker.json"
-    jpath = os.path.join(git_dir, jfile)
+    jpath = os.path.join(git_dir, "MCprep_addon", jfile)
     par_jfile = "mcprep_addon_trackerid.json"
     par_jpath = os.path.join(git_dir, par_jfile)
 

--- a/test_files/tracker_test.py
+++ b/test_files/tracker_test.py
@@ -54,19 +54,6 @@ class TrackingTest(unittest.TestCase):
     def tearDown(self):
         tracking.Tracker = self._backup_tracker
 
-    def test_no_local_idfile(self):
-        """Safety check to ensure we never ship with an id file (again)."""
-        git_dir = os.path.dirname(os.path.dirname(__file__))
-        jfile = "mcprep_addon_tracker.json"
-        jpath = os.path.join(git_dir, jfile)
-        par_jfile = "mcprep_addon_trackerid.json"
-        par_jpath = os.path.join(git_dir, par_jfile)
-
-        self.assertFalse(
-            os.path.isfile(jpath), f"Should not have local {jfile}")
-        self.assertFalse(
-            os.path.isfile(par_jpath), f"Should not have local {par_jfile}")
-
     def test_track_install_integration(self):
         """Ensure there are no exceptions during install."""
         tracking.trackInstalled(background=False)


### PR DESCRIPTION
Two levels of trying to make sure we never ship with tracker code again.

1. Remove the tracker and parent id right after all tests complete
2. Force removal during the release script, after tests but before the zip build is performed.

Removed the test that checks for these file. There was a wrong path which was why it wasn't failing correctly before. Plus, the test itself is basically redundant, since other modules of the test runner are what cause the creation of the tracker files being created in the git folder and thus the file can get generated before and after this test runs. The test runner now cleans itself up instead.

```
-------------------------------------------------------------------------------
bversion   	ran_tests	ran	skips	failed	errors
-------------------------------------------------------------------------------
(3.6.2)   	all_tests	63	2	0	No errors
tests took 16s to run, ending with code 0
```