### PR TITLE
Added warning for using MCprep in a version beyond what was tested

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -30,6 +30,8 @@ from bpy.utils.previews import ImagePreviewCollection
 # TYPING UTILITIES
 # -----------------------------------------------------------------------------
 
+# Upper supported Blender version
+UPPER_BV_CAP = (4, 0, 0)
 
 class Form(enum.Enum):
 	"""Texture or world import interpretation, for mapping or other needs."""
@@ -75,6 +77,7 @@ class MCprepEnv:
 		self.dev_file: Path = Path(os.path.dirname(__file__), "mcprep_dev.txt")
 
 		self.last_check_for_updated = 0
+		self.valid_environment: bool = True
 
 		# Check to see if there's a text file for a dev build. If so,
 		if self.dev_file.exists():
@@ -123,6 +126,11 @@ class MCprepEnv:
 		# that no reading has occurred. If lib not found, will update to [].
 		# If ever changing the resource pack, should also reset to None.
 		self.material_sync_cache = []
+
+		# Implement a hard cap for Blender versions
+		if hasattr(bpy.app, "version"):
+			if bpy.app.version > UPPER_BV_CAP:
+				self.valid_environment = False
 
 	def update_json_dat_path(self):
 		"""If new update file found from install, replace old one with new.

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -99,6 +99,19 @@ def restart_layout(layout):
 		icon="ERROR")
 	col.label(text="to complete update")
 
+def upper_bv_layout(layout):
+	"""Warn about the upper bv limit"""
+	box = layout.box()
+	col = box.column()
+	alert_row = col.row()
+	alert_row.alert = True
+	alert_row.label(text="Your Blender version is above")
+	alert_row = col.row()
+	alert_row.alert = True
+	alert_row.label(text="the supported range. No support")
+	alert_row = col.row()
+	alert_row.alert = True
+	alert_row.label(text="will be provided!")
 
 # -----------------------------------------------------------------------------
 # UI class functions
@@ -289,6 +302,8 @@ class MCPREP_MT_3dview_add(bpy.types.Menu):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(layout)
 		layout = self.layout
 		props = context.scene.mcprep_props
 
@@ -740,7 +755,8 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		if addon_just_updated():
 			# Don't draw restart_layout() here, as we already have a box
 			return
-
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
 		layout = self.layout
 		split = layout.split()
 		col = split.column(align=True)
@@ -885,7 +901,8 @@ class MCPREP_PT_bridge(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
-
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
 		# bridge.panel_draw(self, context)
 		pass
 
@@ -902,6 +919,8 @@ class MCPREP_PT_world_tools(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(layout)
 
 		rw = layout.row()
 		col = rw.column()
@@ -957,7 +976,8 @@ class MCPREP_PT_skins(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(layout)
 			return
-
+		elif not env.valid_environment:
+			upper_bv_layout(layout)
 		scn_props = context.scene.mcprep_props
 		sind = context.scene.mcprep_skins_list_index
 		mob_ind = context.scene.mcprep_props.mob_list_index
@@ -1072,6 +1092,8 @@ class MCPREP_PT_materials(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(layout)
 
 		row = layout.row()
 		# row.operator("mcprep.create_default_material")
@@ -1117,6 +1139,9 @@ class MCPREP_PT_materials_subsettings(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 
 		b_row = self.layout.row()
 		b_col = b_row.column(align=False)
@@ -1676,6 +1701,9 @@ class MCPREP_PT_spawn(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		row = self.layout.row(align=True)
 		row.label(text="Click triangle to open")
 		ops = row.operator(
@@ -1697,6 +1725,9 @@ class MCPREP_PT_mob_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		if not is_obj_mode:
 			draw_mode_warning(self.layout)
@@ -1725,6 +1756,9 @@ class MCPREP_PT_model_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		if not is_obj_mode:
 			draw_mode_warning(self.layout)
@@ -1753,6 +1787,9 @@ class MCPREP_PT_item_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		is_pose_mode = context.mode == "POSE"
 		if not is_obj_mode and not is_pose_mode:
@@ -1782,6 +1819,9 @@ class MCPREP_PT_effects_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		if not is_obj_mode:
 			draw_mode_warning(self.layout)
@@ -1810,6 +1850,9 @@ class MCPREP_PT_entity_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		if not is_obj_mode:
 			draw_mode_warning(self.layout)
@@ -1838,6 +1881,9 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 		if addon_just_updated():
 			restart_layout(self.layout)
 			return
+		elif not env.valid_environment:
+			upper_bv_layout(self.layout)
+
 		is_obj_mode = context.mode == "OBJECT"
 		if not is_obj_mode:
 			draw_mode_warning(self.layout)

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -108,10 +108,20 @@ def upper_bv_layout(layout):
 	alert_row.label(text="Your Blender version is above")
 	alert_row = col.row()
 	alert_row.alert = True
-	alert_row.label(text="the supported range. No support")
+	alert_row.label(text="the range tested with this version.")
 	alert_row = col.row()
 	alert_row.alert = True
-	alert_row.label(text="will be provided!")
+	alert_row.label(text="Please report any issues")
+	alert_row = col.row()
+	alert_row.alert = True
+	alert_row.label(text="that occur!")
+
+	alert_row = col.row()
+	alert_row.alert = True
+	alert_row.operator(
+				"wm.url_open", text="Report a Bug!"
+			).url = "https://github.com/Moo-Ack-Productions/MCprep/issues/new?assignees=&labels=user-troubleshoot&projects=&template=Bug-Report.yml"
+
 
 # -----------------------------------------------------------------------------
 # UI class functions


### PR DESCRIPTION
This will now warn the user when using MCprep in a version of Blender above the upper cap. This is intended to prevent users from thinking that MCprep won't have issues in new Blender versions.

Currently we warn that we won't provide support for MCprep users using a version above the current upper limit, set at 4.0 for now. 

How it looks:
![image](https://github.com/Moo-Ack-Productions/MCprep/assets/75058058/da96fbf0-eb66-4950-93d3-495c6208bff7)

This is to be set with the convention laid out in #508 (subject to change), which defines how we should choose the upper version cap for MCprep