### PR TITLE
Mark optimizer as deprecated

### DIFF
--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -814,8 +814,10 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		icon = "TRIA_DOWN" if scn_props.show_settings_optimizer else "TRIA_RIGHT"
 		row.prop(
 			scn_props, "show_settings_optimizer",
-			text="Cycles Optimizer", icon=icon)
+			text="Cycles Optimizer (Deprecated)", icon=icon)
 		if scn_props.show_settings_optimizer:
+			row = col.row(align=True)
+			row.label(text="The Cycles optimizer will be removed in 3.6!")
 			row = col.row(align=True)
 			optimize_scene.panel_draw(context, row)
 

--- a/MCprep_addon/optimize_scene.py
+++ b/MCprep_addon/optimize_scene.py
@@ -16,6 +16,27 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+# Note from Mahid Sheikh, December 24th, 2023
+# 
+# The MCprep optimizer is to be deprecated in MCprep 3.5.2, and 
+# removed in MCprep 3.6. This is for the following reasons:
+# - Extremely buggy algorithm
+#	- There's been times where MCprep has set the max bounces 
+#     to 80 or higher, because of the way the algorithm assumes
+#	  the scene's properties.
+#
+#	- The algorithm was made to work around the hardware I assumed
+#	  a regular user would have (based on what I've seen on Minecraft
+#	  animation servers), which means no actual scene profiling, just
+#	  assumptions of how the scene could turn out based on materials.
+#
+# - Not caught up with modern Cycles improvements
+#	- This was written when Cycles X was still in development. Today, 
+#	  Cycles has massively improved, and Cycles X is the default, but
+#	  the optimizer hasn't changed at all.
+#
+# - Better tools exist for automatic optimization, though nothing 
+#	beats manual optimization
 
 import bpy
 from bpy.types import Context, UILayout, Node

--- a/MCprep_addon/optimize_scene.py
+++ b/MCprep_addon/optimize_scene.py
@@ -107,7 +107,7 @@ def panel_draw(context: Context, element: UILayout):
 		col.label(text="")
 		subrow = col.row()
 		subrow.scale_y = 1.5
-		subrow.operator("mcprep.optimize_scene", text="Optimize Scene")
+		subrow.operator("mcprep.optimize_scene", text="Optimize Scene (Deprecated)")
 	else:
 		col.label(text="Cycles Only :C")
 


### PR DESCRIPTION
This marks the Cycles optimizer as deprecated in the UI, and alerts the user about the change
![image](https://github.com/Moo-Ack-Productions/MCprep/assets/75058058/f0b4f71a-af50-48a5-85a7-fe3c850a527d)

In addition, `optimize_scene.py` has a note on the deprecation, with the reasons why (mostly a copy+paste from #514)