### PR TITLE
Fix direct socket name reference error in optimizer

### DIFF
--- a/MCprep_addon/optimize_scene.py
+++ b/MCprep_addon/optimize_scene.py
@@ -180,7 +180,10 @@ class MCPrep_OT_optimize_scene(bpy.types.Operator):
 			if not roughness_socket.is_linked and roughness_socket.default_value >= 0.2:
 				self.glossy = self.glossy - 1 if self.glossy > 2 else 2
 		elif mat_type == "glass":
-			transmission_socket = node.inputs["Transmission"]
+			if "Transmission" in node.inputs:  # pre 4.0 way
+				transmission_socket = node.inputs["Transmission"]
+			else:  # Blender 4.0+
+				transmission_socket = node.inputs["Transmission Weight"]
 			if not transmission_socket.is_linked and transmission_socket.default_value >= 0:
 				self.transmissive = self.transmissive - 2 if self.transmissive > 1 else 2
 


### PR DESCRIPTION
This directly fixes the issue identified in https://github.com/Moo-Ack-Productions/MCprep/issues/514

Would create an associated test which could have validated this worked well, but we now have the intention to remove the optimizer anyways, so not worth the extra time to do so.

Should be backwards compatibly safe. When running optimizer on a scene with a large number of materials imported from a world, it seems to now work without raising an error, so I presume this is enough of a change to make for now.