### PR TITLE
Fixed "Find Missing" due to animated image location and added test.

### DIFF
--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -421,7 +421,9 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 				env.log(f"Updated {mat.name}")
 				if self.animateTextures:
 					sequences.animate_single_material(
-						mat, context.scene.render.engine)
+						mat,
+						context.scene.render.engine,
+						export_location=sequences.ExportLocation.ORIGINAL)
 		if count == 0:
 			self.report(
 				{'INFO'},

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -590,7 +590,6 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 		self.track_param = context.scene.render.engine
 		return {'FINISHED'}
 
-
 	def update_material(self, context, mat):
 		"""Update the initially created material"""
 		if not mat:


### PR DESCRIPTION
This operator was already high in terms of test coverage, but the one branch not covered (and, the todo listed) was for animated textures. of course, that was what went wrong. Now it tests this branch too.

All tests pass, including the new one:

```
-------------------------------------------------------------------------------
bversion   	ran_tests	ran	skips	failed	errors
-------------------------------------------------------------------------------
(3.6.2)   	all_tests	64	2	0	No errors
(4.0.2)   	all_tests	64	2	0	No errors
(3.5.1)   	all_tests	64	2	0	No errors
(3.4.0)   	all_tests	64	2	0	No errors
(3.3.1)   	all_tests	64	2	0	No errors
(3.2.1)   	all_tests	64	2	0	No errors
(3.1.0)   	all_tests	64	2	0	No errors
(3.0.0)   	all_tests	64	2	0	No errors
(2.93.0)   	all_tests	63	3	0	No errors
(2.90.1)   	all_tests	63	3	0	No errors
(2.80.75)   	all_tests	62	4	0	No errors
tests took 196s to run, ending with code 0
```

Fixes https://github.com/Moo-Ack-Productions/MCprep/issues/516