### PR TITLE
Added error object for better user experience

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -236,7 +236,6 @@ class MCprepError(object):
 		was created in. The preferred way 
 		to get this is __file__
 	"""
-	msg: Optional[str]
 	err_type: BaseException
 	line: int 
 	file: str

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -18,7 +18,8 @@
 
 from mathutils import Vector
 from pathlib import Path
-from typing import Union, Tuple, List, Dict
+from typing import Optional, Union, Tuple, List, Dict
+from dataclasses import dataclass
 import enum
 import os
 
@@ -207,6 +208,54 @@ class MCprepEnv:
 			self.log("Deprecation Warning: This will be removed in MCprep 3.5.1!")
 			traceback.print_stack()
 
+class ErrorType(enum.Enum):
+	"""
+	All error types
+
+	Attributes
+	------------
+	FILE_NOT_FOUND:
+		File was not found
+	"""
+	FILE_NOT_FOUND = enum.auto()
+
+@dataclass
+class MCprepError(object):
+	"""
+	Object that is returned when 
+	an error occurs. This is meant
+	to give more information to the 
+	caller so that a better error 
+	message can be made
+
+	Attributes
+	------------
+	msg: Optional[str]
+		Error message. This is optional
+		as the caller may want to use
+		their own error message based
+		on the context
+	
+	err_type: ErrorType
+		The error type; unique for each
+		type of error
+
+	line: int
+		Line the exception object was 
+		created on. The preferred method 
+		to do this is to use currentframe 
+		and getframeinfo from the inspect 
+		module
+
+	file: str
+		Path of file the exception object
+		was created in. The preferred way 
+		to get this is __file__
+	"""
+	msg: Optional[str]
+	err_type: ErrorType
+	line: int 
+	file: str
 
 env = MCprepEnv()
 

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -208,17 +208,6 @@ class MCprepEnv:
 			self.log("Deprecation Warning: This will be removed in MCprep 3.5.1!")
 			traceback.print_stack()
 
-class ErrorType(enum.Enum):
-	"""
-	All error types
-
-	Attributes
-	------------
-	FILE_NOT_FOUND:
-		File was not found
-	"""
-	FILE_NOT_FOUND = enum.auto()
-
 @dataclass
 class MCprepError(object):
 	"""
@@ -230,15 +219,10 @@ class MCprepError(object):
 
 	Attributes
 	------------
-	msg: Optional[str]
-		Error message. This is optional
-		as the caller may want to use
-		their own error message based
-		on the context
-	
-	err_type: ErrorType
-		The error type; unique for each
-		type of error
+	err_type: BaseException
+		The error type; uses standard 
+		Python exceptions
+		
 
 	line: int
 		Line the exception object was 
@@ -253,7 +237,7 @@ class MCprepError(object):
 		to get this is __file__
 	"""
 	msg: Optional[str]
-	err_type: ErrorType
+	err_type: BaseException
 	line: int 
 	file: str
 


### PR DESCRIPTION
In the past, MCprep used many methods to determine if an error occurred somewhere outside an operator, such as checking for `None`, using `1` to signify an exception, etc. These methods have the following issues though:
- Not descriptive for the caller; the caller knows an error occurred somewhere, but doesn't know where. This makes it difficult to create a well crafted error message, which makes errors harder to troubleshoot
- Inconsistent, which makes MCprep's code harder to understand.

To mitigate these issues in new code, a new error class is needed. This PR introduces the `MCprepError` class, which aims to give error messages enough information one needs to debug. With `MCprepError`, the following can be used as general rules:
- The function that returns an object is responsible for providing the following:
	- Error type 
	- File and line number (this is where the `inspect` module comes in handy)
	- Error message (optional, as some functions might be general purpose)
- The function that receives the error is responsible for the following:
	- Graceful handling of the error
	- Alerting the user of the error, *with all the information provided by the error object*

To bring this out to devs, this PR doesn't perform any actual migration of old code, hence why it's pretty lackluster. The goal is to migrate as we go.