### PR TITLE
Refactored colorspace setup to be more flexible

### DIFF
--- a/MCprep_addon/MCprep_resources/mcprep_data_update.json
+++ b/MCprep_addon/MCprep_resources/mcprep_data_update.json
@@ -4407,5 +4407,10 @@
 		"sunflower",
 		"water_still",
 		"water"
+	],
+	"non_color_options" : [
+		"Non-Color",
+		"Non-Colour Data",
+		"NONE"
 	]
 }

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -69,7 +69,7 @@ except:
 class MCprepEnv:
 	def __init__(self):
 		self.data = None
-		self.json_data = None
+		self.json_data: Optional[Dict] = None
 		self.json_path: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data.json")
 		self.json_path_update: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data_update.json")
 
@@ -207,6 +207,38 @@ class MCprepEnv:
 			import traceback
 			self.log("Deprecation Warning: This will be removed in MCprep 3.5.1!")
 			traceback.print_stack()
+
+	def current_line_and_file(self) -> Tuple[int, str]:
+		"""
+		Wrapper to get the current line number and file path for
+		MCprepError.
+
+		This function can not return an MCprepError value as doing
+		so would be more complicated for the caller. As such, if 
+		this fails, we return values -1 and "UNKNOWN LOCATION" to 
+		indicate that we do not know the line number or file path 
+		the error occured on.
+
+		Returns:
+			- If success: Tuple[int, str] representing the current 
+			line and file path 
+
+			- If fail: (-1, "UNKNOWN LOCATION")
+		"""
+		from inspect import currentframe, getframeinfo
+		cur_frame = currentframe()
+		# currentframe can return a None value
+		# in certain cases
+		if cur_frame:
+			# Get the previous frame since the
+			# current frame is made for this function,
+			# not the function/code that called 
+			# this function
+			prev_frame = cur_frame.f_back
+			if prev_frame:
+				frame_info = getframeinfo(prev_frame)
+				return frame_info.lineno, frame_info.filename
+		return -1, "UNKNOWN LOCATION"
 
 @dataclass
 class MCprepError(object):

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -54,6 +54,12 @@ VectorType = Union[Tuple[float, float, float], Vector]
 Skin = Tuple[str, Path]
 Entity = Tuple[str, str, str]
 
+# Represents an unknown location 
+# for MCprepError. Given a global 
+# constant to make it easier to use
+# and check for
+UNKNOWN_LOCATION = (-1, "UNKNOWN LOCATION")
+
 # check if custom preview icons available
 try:
 	import bpy.utils.previews
@@ -229,16 +235,19 @@ class MCprepEnv:
 		# currentframe can return a None value
 		# in certain cases
 		cur_frame = inspect.currentframe()
-		if cur_frame:
-			# Get the previous frame since the
-			# current frame is made for this function,
-			# not the function/code that called 
-			# this function
-			prev_frame = cur_frame.f_back
-			if prev_frame:
-				frame_info = inspect.getframeinfo(prev_frame)
-				return frame_info.lineno, frame_info.filename
-		return -1, "UNKNOWN LOCATION"
+		if not cur_frame:
+			return UNKNOWN_LOCATION
+		
+		# Get the previous frame since the
+		# current frame is made for this function,
+		# not the function/code that called 
+		# this function
+		prev_frame = cur_frame.f_back
+		if not prev_frame:
+			return UNKNOWN_LOCATION
+
+		frame_info = inspect.getframeinfo(prev_frame)
+		return frame_info.lineno, frame_info.filename
 
 @dataclass
 class MCprepError(object):

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -19,6 +19,7 @@
 from mathutils import Vector
 from pathlib import Path
 from typing import Optional, Union, Tuple, List, Dict
+import inspect
 from dataclasses import dataclass
 import enum
 import os
@@ -225,10 +226,9 @@ class MCprepEnv:
 
 			- If fail: (-1, "UNKNOWN LOCATION")
 		"""
-		from inspect import currentframe, getframeinfo
-		cur_frame = currentframe()
 		# currentframe can return a None value
 		# in certain cases
+		cur_frame = inspect.currentframe()
 		if cur_frame:
 			# Get the previous frame since the
 			# current frame is made for this function,
@@ -236,7 +236,7 @@ class MCprepEnv:
 			# this function
 			prev_frame = cur_frame.f_back
 			if prev_frame:
-				frame_info = getframeinfo(prev_frame)
+				frame_info = inspect.getframeinfo(prev_frame)
 				return frame_info.lineno, frame_info.filename
 		return -1, "UNKNOWN LOCATION"
 

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -419,9 +419,12 @@ def set_cycles_texture(
 			if "normal" in img_sets:
 				new_img = util.loadTexture(img_sets["normal"])
 				node.image = new_img
-				util.apply_colorspace(node, 'Non-Color')
 				node.mute = False
 				node.hide = False
+				
+				res = util.apply_noncolor_data(node)
+				if res is not None:
+					env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 			else:
 				node.mute = True
 				node.hide = True
@@ -436,7 +439,9 @@ def set_cycles_texture(
 				node.image = new_img
 				node.mute = False
 				node.hide = False
-				util.apply_colorspace(node, 'Non-Color')
+				res = util.apply_noncolor_data(node)
+				if res is not None:
+					env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 			else:
 				node.mute = True
 				node.hide = True
@@ -971,8 +976,12 @@ def texgen_specular(mat: Material, passes: Dict[str, Image], nodeInputs: List, u
 		nodeNormal.mute = True
 
 	# Update to use non-color data for spec and normal
-	util.apply_colorspace(nodeTexSpec, 'Non-Color')
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+	res = util.apply_noncolor_data(nodeTexSpec)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
+	res = util.apply_noncolor_data(nodeTexNorm)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 
 	# Graystyle Blending
 	if not checklist(canon, "desaturated"):
@@ -1113,8 +1122,12 @@ def texgen_seus(mat: Material, passes: Dict[str, Image], nodeInputs: List, use_r
 		nodeNormal.mute = True
 
 	# Update to use non-color data for spec and normal
-	util.apply_colorspace(nodeTexSpec, 'Non-Color')
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+	res = util.apply_noncolor_data(nodeTexSpec)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
+	res = util.apply_noncolor_data(nodeTexNorm)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 
 	# Graystyle Blending
 	if not checklist(canon, "desaturated"):
@@ -1795,7 +1808,9 @@ def matgen_special_water(mat: Material, passes: Dict[str, Image]) -> Optional[bo
 	links.new(nodeNormal.outputs[0], nodeGlass.inputs[3])
 
 	# Normal update
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+	res = util.apply_noncolor_data(nodeTexNorm)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 	if image_norm:
 		nodeTexNorm.image = image_norm
 		nodeTexNorm.mute = False
@@ -1929,7 +1944,9 @@ def matgen_special_glass(mat: Material, passes: Dict[str, Image]) -> Optional[bo
 	links.new(nodeNormal.outputs[0], nodeDiff.inputs[2])
 
 	# Normal update
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+	res = util.apply_noncolor_data(nodeTexNorm)
+	if res is not None:
+		env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
 	if image_norm:
 		nodeTexNorm.image = image_norm
 		nodeTexNorm.mute = False

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -39,7 +39,7 @@ from bpy.types import (
 )
 from mathutils import Vector, Matrix
 
-from .conf import env
+from .conf import MCprepError, env
 
 # Commonly used name for an excluded collection in Blender 2.8+
 SPAWNER_EXCLUDE = "Spawner Exclude"
@@ -48,31 +48,45 @@ SPAWNER_EXCLUDE = "Spawner Exclude"
 # GENERAL SUPPORTING FUNCTIONS (no registration required)
 # -----------------------------------------------------------------------------
 
-
-def apply_colorspace(node: Node, color_enum: Tuple) -> None:
-	"""Apply color space in a cross compatible way, for version and language.
-
-	Use enum nomeclature matching Blender 2.8x Default, not 2.7 or other lang
+def apply_noncolor_data(node: Node) -> Optional[MCprepError]:
 	"""
-	global noncolor_override
-	noncolor_override = None
+	Apply the Non-Color/Generic Data option to the passed
+	node in a way that is cross version compatible, as well as OCIO
+	config compatible in theory.
+	
+	Returns:
+		If success: None
+		If fail: 
+			All cases - MCprepError(TypeError)
+	"""
+	options: List[str] = []
+	if env.json_data:
+		options = env.json_data["non_color_options"]
 
 	if not node.image:
 		env.log("Node has no image applied yet, cannot change colorspace")
-
-	# For later 2.8, fix images color space user
-	if hasattr(node, "color_space"):  # 2.7 and earlier 2.8 versions
-		node.color_space = 'NONE'  # for better interpretation of specmaps
-	elif hasattr(node.image, "colorspace_settings"):  # later 2.8 versions
-		# try default 'Non-color', fall back to best guess 'Non-Colour Data'
-		if color_enum == 'Non-color' and noncolor_override is not None:
-			node.image.colorspace_settings.name = noncolor_override
-		else:
+	
+	# While earlier versions of 2.8 used a different 
+	# attribute name for colorspace, MCprep officially 
+	# supports the full 2.8 release at a minimum (as of 3.5)
+	if hasattr(node.image, "colorspace_settings"):
+		# Avoid hard-coding values into the 
+		# code so that users with non-standard
+		# setups can add whatever additional 
+		# options are needed for their OCIO
+		# setup
+		for opt in options:
 			try:
-				node.image.colorspace_settings.name = 'Non-Color'
-			except TypeError:
-				node.image.colorspace_settings.name = 'Non-Colour Data'
-				noncolor_override = 'Non-Colour Data'
+				node.image.colorspace_settings.name = opt
+				return None
+			except TypeError:	
+				continue
+	(lineno, file) = env.current_line_and_file()
+	return MCprepError(
+		TypeError("None of the non-color options work, add a new option to mcprep_data.json"),
+		lineno,
+		file
+	)
 
 
 def nameGeneralize(name: str) -> str:
@@ -453,7 +467,8 @@ def load_mcprep_json() -> bool:
 			"canon_mapping_block": {}
 		},
 		"mob_skip_prep": [],
-		"make_real": []
+		"make_real": [],
+		"non_color_options" : [],
 	}
 	if not os.path.isfile(path):
 		env.log(f"Error, json file does not exist: {path}")

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -66,9 +66,7 @@ def apply_noncolor_data(node: Node) -> Optional[MCprepError]:
 	if not node.image:
 		env.log("Node has no image applied yet, cannot change colorspace")
 	
-	# While earlier versions of 2.8 used a different 
-	# attribute name for colorspace, MCprep officially 
-	# supports the full 2.8 release at a minimum (as of 3.5)
+	# Blender 2.8+
 	if hasattr(node.image, "colorspace_settings"):
 		# Avoid hard-coding values into the 
 		# code so that users with non-standard


### PR DESCRIPTION
In the past, we'd set this to a hard coded value. However, that proved to be annoying to users using non-standard OCIO configs like ACES or early versions of AgX. MCprep already fixes MTL files for ACES compatibility, so we're expanding this to prep materials.

In `mcprep_data.json`, there will now be a section called "non_color_options", which is a list of different options for Non-Color Data/Generic Data. If a user is using a non-standard setup, they can simply add the correct option in the JSON file and prep materials will function properly.

The matching goes in order from first to last, and MCprep will use the first value matched at runtime.