### PR TITLE
Adding material no_prep properties

### DIFF
--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -250,13 +250,13 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 
 			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 				options = generate.PrepOptions(
-					passes, 
+					passes,
 					self.useReflections,
 					self.usePrincipledShader,
 					self.makeSolid,
-					self.packFormat,
+					generate.PackFormat[self.packFormat.upper()],
 					self.useEmission,
-					False # This is for an option set in matprep_cycles
+					False  # This is for an option set in matprep_cycles
 				)
 				res = generate.matprep_cycles(
 					mat=mat,

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -215,7 +215,6 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 			elif mat.get("MCPREP_NO_PREP", False):
 				count_no_prep += 1
 				continue
-			
 			elif mat.library:
 				count_lib_skipped += 1
 				continue
@@ -273,7 +272,9 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 
 			if self.animateTextures:
 				sequences.animate_single_material(
-					mat, context.scene.render.engine)
+					mat,
+					context.scene.render.engine,
+					export_location=sequences.ExportLocation.ORIGINAL)
 
 		# Sync materials.
 		if self.syncMaterials is True:

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -251,11 +251,11 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 				options = generate.PrepOptions(
 					passes, 
-					self.useReflections, 
-					self.usePrincipledShader, 
-					self.makeSolid, 
-					self.packFormat, 
-					self.useEmission, 
+					self.useReflections,
+					self.usePrincipledShader,
+					self.makeSolid,
+					self.packFormat,
+					self.useEmission,
 					False # This is for an option set in matprep_cycles
 				)
 				res = generate.matprep_cycles(
@@ -284,7 +284,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 		if self.combineMaterials is True:
 			bpy.ops.mcprep.combine_materials(selection_only=True, skipUsage=True)
 
-        # Improve UI.
+		# Improve UI.
 		if self.improveUiSettings:
 			try:
 				bpy.ops.mcprep.improve_ui()

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -212,7 +212,6 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 				env.log(
 					"During prep, found null material:" + str(mat), vv_only=True)
 				continue
-
 			elif mat.get("MCPREP_NO_PREP", False):
 				count_no_prep += 1
 				continue
@@ -268,7 +267,8 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 			else:
 				self.report(
 					{'ERROR'},
-					"Only Cycles and Eevee are supported")
+					"Only Cycles and Eevee are supported"
+				)
 				return {'CANCELLED'}
 
 			if self.animateTextures:
@@ -303,7 +303,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 		_info[f"skipped {count_lib_skipped} linked"] = has_lib_skipped
 		_info[f"founded {count_no_prep} no prep"] = has_no_prep
 		
-		mat_info = ",".join(k for k,v in _info.items() if v).capitalize()
+		mat_info = ", ".join(k for k, v in _info.items() if v).capitalize()
 		
 		if self.skipUsage is True:
 			pass  # Don't report if a meta-call.

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -212,10 +212,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 				env.log(
 					"During prep, found null material:" + str(mat), vv_only=True)
 				continue
-			elif mat.get("MCPREP_NO_PREP", False):
-				count_no_prep += 1
-				continue
-			elif mat.library:
+			elif mat.library or mat.get("MCPREP_NO_PREP", False):
 				count_lib_skipped += 1
 				continue
 
@@ -295,20 +292,20 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 		if self.optimizeScene and engine == 'CYCLES':
 			bpy.ops.mcprep.optimize_scene()
 
-		has_no_prep = count_no_prep > 0
 		has_lib_skipped = count_lib_skipped > 0
 		has_mat = count > 0
 		
-		_info = {}
-		_info[f"modified {count}"] = has_mat
-		_info[f"skipped {count_lib_skipped} linked"] = has_lib_skipped
-		_info[f"founded {count_no_prep} no prep"] = has_no_prep
+		info = []
+		if has_mat:
+			info.append(f"modified {count}")
+		if has_lib_skipped:
+			info.append(f"skipped {count_lib_skipped}")
 		
-		mat_info = ", ".join(k for k, v in _info.items() if v).capitalize()
+		mat_info = ", ".join(x for x in info).capitalize()
 		
 		if self.skipUsage is True:
 			pass  # Don't report if a meta-call.
-		elif has_mat or has_lib_skipped or has_no_prep:
+		elif has_mat or has_lib_skipped:
 			self.report({"INFO"}, mat_info) 
 		else:
 			self.report(


### PR DESCRIPTION
This is a part of #440 splitted into many PRs. 
This first introduce `MCPREP_NO_PREP` properties under material, this is useful for material doesn't want MCprep prep material overwrites it like on some rigs have been defined in the [json](https://github.com/Moo-Ack-Productions/MCprep/blob/c7622a626e7495db5919d63149f0cfc53fe62b14/MCprep_addon/MCprep_resources/mcprep_data_update.json#L4384) file `"mob_skip_prep"`.  

Additional question:
- Should there an option on prep material to force prepping this skipped no prep?

![image](https://github.com/Moo-Ack-Productions/MCprep/assets/61040487/c7684336-3995-4a60-86c3-f3ff9c9e2dbf)
