### PR TITLE
build: Fixed issue with BpyError return values

### DIFF
--- a/action-scripts/translate.py
+++ b/action-scripts/translate.py
@@ -1,15 +1,24 @@
+from typing import Optional
 from translate_scripts import build_pot, build_trans_dict, compile_po_to_mo
-from bpy_addon_build.api import BabContext
+from bpy_addon_build.api import BabContext, BpyError
 import sys
 
-def pre_build(ctx: BabContext) -> None:
+def pre_build(ctx: BabContext) -> Optional[BpyError]:
     sys.stdout.reconfigure(encoding='utf-8')
-    build_pot.pre_build(ctx)
+    return build_pot.pre_build(ctx)
 
 def main():
     sys.stdout.reconfigure(encoding='utf-8')
-    compile_po_to_mo.main()
-    build_trans_dict.main()
+    
+    # Go through each module, and 
+    # run its main function, while checking 
+    # for a return value
+    modules = [compile_po_to_mo, build_trans_dict]
+    for mod in modules:
+        res = mod.main()
+        if res:
+            continue 
+        return res
 
 if __name__ == "__main__":
     main()

--- a/action-scripts/translate.py
+++ b/action-scripts/translate.py
@@ -15,10 +15,9 @@ def main():
     # for a return value
     modules = [compile_po_to_mo, build_trans_dict]
     for mod in modules:
-        res = mod.main()
-        if res:
-            continue 
-        return res
+        error = mod.main()
+        if error:
+            return error
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This fixes the issue noted in https://github.com/Moo-Ack-Productions/bpy-build/issues/14, which actually isn't a BpyBuild issue, but rather an issue with our `translate` action. 

For `translate`, we have a `translate.py` script (what BpyBuild actually works with) and a bunch of subscripts in `translate_scripts`, which perform individual actions. However, the `pre_build` function in `translate.py` didn't return the results of those subscripts. So when `build_pot.py` returns an error, that error wasn't propogated, so BpyBuild wouldn't know there was an error.

Closes https://github.com/Moo-Ack-Productions/bpy-build/issues/14