### PR TITLE
build: Reconfigure is called outside of BpyBuild tests

### DIFF
--- a/action-scripts/translate.py
+++ b/action-scripts/translate.py
@@ -2,13 +2,16 @@ from typing import Optional
 from translate_scripts import build_pot, build_trans_dict, compile_po_to_mo
 from bpy_addon_build.api import BabContext, BpyError
 import sys
+import io
 
 def pre_build(ctx: BabContext) -> Optional[BpyError]:
-    sys.stdout.reconfigure(encoding='utf-8')
+    if not isinstance(sys.stdout, io.StringIO):
+        sys.stdout.reconfigure(encoding='utf-8')
     return build_pot.pre_build(ctx)
 
 def main():
-    sys.stdout.reconfigure(encoding='utf-8')
+    if not isinstance(sys.stdout, io.StringIO):
+        sys.stdout.reconfigure(encoding='utf-8')
     
     # Go through each module, and 
     # run its main function, while checking 


### PR DESCRIPTION
Resolves https://github.com/Moo-Ack-Productions/bpy-build/pull/16#issuecomment-2146677253

In normal use, [`sys.stdout.reconfigure(encoding='utf-8')`](https://docs.python.org/3/library/io.html#io.TextIOWrapper.reconfigure) is perfectly fine to call. However, in BpyBuild tests, this causes an error, as BpyBuild patches `sys.stdout` to use [`io.StringIO`](https://docs.python.org/3/library/io.html#io.StringIO) in order to check command output. As such, a check has been added to only call `sys.stdout.reconfigure(encoding='utf-8')` outside of BpyBuild tests
