### PR TITLE
feat: Enable EEVEE Next support

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -44,9 +44,11 @@ class Form(enum.Enum):
 class Engine(enum.Enum):
 	"""String exact match to output from blender itself for branching."""
 	CYCLES = "CYCLES"
+
+	# Blender 2.8 to 4.1
 	BLENDER_EEVEE = "BLENDER_EEVEE"
-	# EEVEE Next is the next generation EEVEE. So in preperation for that,
-	# we've added "BLENDER_EEVEE_NEXT" as an Engine option
+
+	# Blender 4.2 and beyond
 	BLENDER_EEVEE_NEXT = "BLENDER_EEVEE_NEXT"
 
 

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -1169,7 +1169,7 @@ def generate_base_material(
 	mat = bpy.data.materials.new(name=name)
 
 	engine = context.scene.render.engine
-	if engine in ['CYCLES', 'BLENDER_EEVEE']:
+	if engine in ['CYCLES', 'BLENDER_EEVEE', 'BLENDER_EEVEE_NEXT']:
 		# need to create at least one texture node first, then the rest works
 		mat.use_nodes = True
 		nodes = mat.node_tree.nodes

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -450,7 +450,7 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 		image = bpy.data.images.load(image_path, check_existing=True)
 
 		engine = bpy.context.scene.render.engine
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			status = generate.set_cycles_texture(image, mat)
 		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
 			status = generate.set_cycles_texture(image, mat)

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -130,7 +130,7 @@ def draw_mats_common(self, context: Context) -> None:
 	row = self.layout.row()
 	col = row.column()
 	engine = context.scene.render.engine
-	if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+	if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 		col.prop(self, "packFormat")
 		col.prop(self, "usePrincipledShader")
 	col.prop(self, "useReflections")
@@ -244,7 +244,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 					if res > 0:
 						mat["texture_swapped"] = True  # used to apply saturation
 
-			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 				options = generate.PrepOptions(
 					passes,
 					self.useReflections,
@@ -621,7 +621,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 				if res > 0:
 					mat["texture_swapped"] = True  # used to apply saturation
 
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			options = generate.PrepOptions(
 				passes=passes,
 				use_reflections=self.useReflections,

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -111,7 +111,7 @@ def animate_single_material(
 		if not tile_path_dict[pass_name]:  # ie ''
 			env.log(f"Skipping passname: {pass_name}")
 			continue
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			node = generate.get_node_for_pass(mat, pass_name)
 			if not node:
 				continue

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -238,7 +238,7 @@ def spawn_item_from_filepath(
 			mat.use_transparency = 1
 			mat.alpha = 0
 			mat.texture_slots[0].use_map_alpha = 1
-	elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+	elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 		mat.use_nodes = True
 		nodes = mat.node_tree.nodes
 		links = mat.node_tree.links

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -136,7 +136,7 @@ def add_material(
 			passes[pass_name] = None
 	# Prep material
 	# Halt if no diffuse image found
-	if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+	if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 		options = generate.PrepOptions(
 			passes=passes,
 			use_reflections=False,

--- a/MCprep_addon/spawner/mobs.py
+++ b/MCprep_addon/spawner/mobs.py
@@ -256,7 +256,7 @@ class MCPREP_OT_mob_spawner(bpy.types.Operator):
 		row.prop(self, "clearPose")
 		row = self.layout.row(align=True)
 		engine = context.scene.render.engine
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			row.prop(self, "prep_materials")
 		else:
 			row.prop(self, "prep_materials", text="Prep materials")

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -660,7 +660,7 @@ class MCPREP_OT_prep_world(bpy.types.Operator):
 			context.scene.world = bpy.data.worlds.new("MCprep world")
 		if engine == 'CYCLES':
 			self.prep_world_cycles(context)
-		elif engine == 'BLENDER_EEVEE':
+		elif engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			self.prep_world_eevee(context)
 		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
 			self.prep_world_internal(context)
@@ -802,7 +802,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 		"""Dynamic set of enums to show based on engine"""
 		engine = bpy.context.scene.render.engine
 		enums = []
-		if bpy.app.version >= (2, 77) and engine in ("CYCLES", "BLENDER_EEVEE"):
+		if bpy.app.version >= (2, 77) and engine in ("CYCLES", "BLENDER_EEVEE", "BLENDER_EEVEE_NEXT"):
 			enums.append((
 				"world_shader",
 				"Dynamic sky + shader sun/moon",
@@ -882,7 +882,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 
 		engine = context.scene.render.engine
 		wname = None
-		if engine == "BLENDER_EEVEE":
+		if engine == "BLENDER_EEVEE" or engine == "BLENDER_EEVEE_NEXT":
 			blend = "clouds_moon_sun_eevee.blend"
 			wname = "MCprepWorldEevee"
 		else:
@@ -909,7 +909,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 				world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
 			bpy.ops.mcprep.world(skipUsage=True)  # do rest of sky setup
 
-		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
 			if not os.path.isfile(blendfile):
 				self.report(
 					{'ERROR'},


### PR DESCRIPTION
EEVEE Next has now been enabled in Blender 4.2, [with EEVEE Legacy being removed](https://projects.blender.org/blender/blender/commit/cc0d12dd20a7ff93a962c7ebc523d85c3506b26b). In order to make sure addons don't silently error out, EEVEE Next uses a different identifier (`BLENDER_EEVEE_NEXT`), so this commit adds support for MCprep by adding the EEVEE Next identifier to the list of supported engines.

RIP EEVEE Legacy, you have served the community well

Closes #583 