### PR TITLE
Updated the test script for obj importing in 4.0+ and expanded gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ venv/
 *.sublime-*
 MCprep_addon/import_bridge/conf
 MCprep_addon/import_bridge/nbt
+MCprep_addon/MCprep_resources/

--- a/test_files/world_tools_test.py
+++ b/test_files/world_tools_test.py
@@ -161,7 +161,13 @@ class WorldToolsTest(unittest.TestCase):
 
     def test_enable_obj_importer(self):
         """Ensure module name is correct, since error won't be reported."""
-        bpy.ops.preferences.addon_enable(module="io_scene_obj")
+        if bpy.app.version < (4, 0):
+            res = bpy.ops.preferences.addon_enable(module="io_scene_obj")
+            self.assertEqual(res, {'FINISHED'})
+        else:
+            in_import_scn = "obj_import" in dir(bpy.ops.wm)
+            self.assertTrue(in_import_scn, "obj_import operator not found")
+
 
     def test_world_import_jmc_full(self):
         test_subpath = os.path.join(


### PR DESCRIPTION
tbh I'm a bit confused how tests were passing on github actions since the obj enabling test *should* have been failing. Let's see what happens now.