### PR TITLE
test: Restrict test action to changes in MCprep_addon

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -19,6 +19,9 @@ on:
     branches:
       - dev
       - main
+    paths:
+      - 'MCprep_addon/**'
+
 
 #run-name: Test on ${{ inputs.blender_versions || true && "4.1.1" }}
 run-name: Test on ${{ inputs.blender_versions }}


### PR DESCRIPTION
This makes it so tests only run if anything in `MCprep_addon` is changed, in order to prevent unnecessary tests on PRs that modify say documentation