### PR TITLE
issues: Add "MCprep Issue" to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug-Report.yml
@@ -1,5 +1,5 @@
-name: Bug Report
-description: File a bug report
+name: Bug Report/MCprep Issue
+description: Report a bug/MCprep issue
 labels: ["user-troubleshoot"]
 body:
   - type: markdown


### PR DESCRIPTION
By doing this, we can get less people to click the "blank issue" option when filing a bug report on GitHub.