### PR TITLE
Improved error message when prepping only mats with missing image paths.

### DIFF
--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -207,7 +207,10 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 		engine = context.scene.render.engine
 		count = 0
 		count_lib_skipped = 0
-		count_no_prep = 0
+		count_img_not_found = 0
+		count_misc_no_prep = 0
+
+		print("Orig mat list: ", len(mat_list))
 
 		for mat in mat_list:
 			if not mat:
@@ -262,6 +265,10 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 				)
 				if res == 0:
 					count += 1
+				elif res == generate.IMG_MISSING:
+					count_img_not_found += 1
+				else:
+					count_misc_no_prep += 1
 			else:
 				self.report(
 					{'ERROR'},
@@ -296,19 +303,25 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 
 		has_lib_skipped = count_lib_skipped > 0
 		has_mat = count > 0
-		
+		has_missing = count_img_not_found > 0
+
 		info = []
 		if has_mat:
 			info.append(f"modified {count}")
 		if has_lib_skipped:
 			info.append(f"skipped {count_lib_skipped}")
-		
+
 		mat_info = ", ".join(x for x in info).capitalize()
-		
+
 		if self.skipUsage is True:
 			pass  # Don't report if a meta-call.
 		elif has_mat or has_lib_skipped:
-			self.report({"INFO"}, mat_info) 
+			self.report({"INFO"}, mat_info)
+		elif has_missing:
+			self.report(
+				{"ERROR"},
+				"Nothing modified, due missing image paths - try advanced: Find Missing Textures or File > External Data > Find Missing Files"
+			)
 		else:
 			self.report(
 				{"ERROR"},


### PR DESCRIPTION
Also resolves some pep8 warnings.

Local tests pass, but let's see about the github action runner. Tested off of a version of dev initially where the find missing function wasn't yet working, to prove the new message displays then. Also cleans up error code responses (though hm maybe we should just use the MCprep error class? though it's helpful to have the specific errno codes to check against right after).