### PR TITLE
Fixing typing which was breaking blender 2.90 and 2.80 builds

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -18,7 +18,7 @@ on:
     types: [opened, reopened, synchronize]  # drop synchronize not run per commit
     branches:
       - dev
-      - main
+      - master
     paths:
       - 'MCprep_addon/**'
 

--- a/MCprep_addon/commonmcobj_parser.py
+++ b/MCprep_addon/commonmcobj_parser.py
@@ -93,7 +93,8 @@ class CommonMCOBJ:
     # Original header
     original_header: Optional[str]
 
-def parse_common_header(header_lines: list[str]) -> CommonMCOBJ:
+
+def parse_common_header(header_lines: List[str]) -> CommonMCOBJ:
     """
     Parses the CommonMCOBJ header information from a list of strings.
 


### PR DESCRIPTION
Also fixing the name for the test runner on master, which wasn't triggering before.

All tests pass across all versions of blender I have locally now

```
-------------------------------------------------------------------------------
bversion   	ran_tests	ran	skips	failed	errors
-------------------------------------------------------------------------------
(4.2.0)   	all_tests	69	2	0	No errors
(4.0.2)   	all_tests	69	2	0	No errors
(3.6.2)   	all_tests	69	2	0	No errors
(3.5.1)   	all_tests	69	2	0	No errors
(3.4.0)   	all_tests	69	2	0	No errors
(3.3.1)   	all_tests	69	2	0	No errors
(3.2.1)   	all_tests	69	2	0	No errors
(3.1.0)   	all_tests	69	2	0	No errors
(3.0.0)   	all_tests	69	2	0	No errors
(2.93.0)   	all_tests	68	3	0	No errors
(2.90.1)   	all_tests	68	3	0	No errors
(2.80.75)   	all_tests	67	4	0	No errors
tests took 303s to run, ending with code 0
```