### PR TITLE
fix: Allow an exporter to be opened without an object selected

### DIFF
--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -753,7 +753,11 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		row = col.row(align=True)
 		row.prop(addon_prefs, "MCprep_exporter_type", expand=True)
 		row = col.row(align=True)
-		exporter = world_tools.get_exporter(context)
+
+		compliant_exporter = world_tools.get_exporter(context)
+		exporter = compliant_exporter if compliant_exporter is not None else world_tools.get_explicit_exporter_legacy(context)
+		del compliant_exporter
+
 		if exporter is None:
 			row.operator(
 				"mcprep.open_jmc2obj", text=env._("Select exporter!"), icon='ERROR')

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -788,7 +788,9 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		if context.mode == "OBJECT":
 			col.operator("mcprep.meshswap", text=env._("Mesh Swap"))
 			exporter = world_tools.get_exporter(context)
-			if exporter is None or exporter is world_tools.WorldExporter.Unknown:
+			if not context.object and not context.selected_objects:
+				pass
+			elif exporter is None or exporter is world_tools.WorldExporter.Unknown:
 				col.label(text=env._("Select exporter!"), icon='ERROR')
 		if context.mode == 'EDIT_MESH':
 			col.operator("mcprep.scale_uv")

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -183,13 +183,24 @@ def get_exporter(context: Context) -> Optional[WorldExporter]:
 	# This section will be placed behind a legacy
 	# option in MCprep 4.0, once CommonMCOBJ becomes
 	# more adopted in exporters
+	return get_explicit_exporter_legacy(context)
+
+def get_explicit_exporter_legacy(context: Context) -> Optional[WorldExporter]:
+	"""Return the explicit exporter setting set in the MCPrep UI (Warning: Not CommonMCOBJ Compliant!)
+
+	Unlike get_exporter, this doesn't depend on an object being selected, but
+	as a result is not CommonMCOBJ compliant (as this is based on an explicit
+	setting for the world exporter and not giving the OBJ the chance to declare
+	its exporter explicitly. This is meant for a few edge cases where the user might
+	want to do something that depends on an exporter being known, but without selecting 
+	an object, such as in a startup file and having the ability to open Mineways or jmc2OBJ.
+	"""
 	prefs = util.get_user_preferences(context)
 	if prefs.MCprep_exporter_type == "Mineways":
 		return WorldExporter.ClassicMW
 	elif prefs.MCprep_exporter_type == "jmc2obj":
 		return WorldExporter.ClassicJmc
 	return None
-
 
 def detect_world_exporter(filepath: Path) -> Union[CommonMCOBJ, ObjHeaderOptions]:
 	"""Detect whether Mineways or jmc2obj was used, based on prefix info.


### PR DESCRIPTION
This fixes an edge case where a user may want to open an exporter from MCprep without an object selected, such as in a startup file without the default cube. 