### PR TITLE
fix: Gracefully handle exceptions during direct i18n loading

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -143,15 +143,21 @@ class MCprepEnv:
 		# i18n using Python's gettext module
 		#
 		# This only runs if translations.py does not exist
-		if not self.translations.exists():
-			self.languages: dict[str, gettext.NullTranslations] = {}
-			for language in self.languages_folder.iterdir():
-				self.languages[language.name] = gettext.translation("mcprep", 
-										 self.languages_folder, 
-										 fallback=True,
-										 languages=[language.name])
+		try:
+			if not self.translations.exists():
+				self.languages: dict[str, gettext.NullTranslations] = {}
+				for language in self.languages_folder.iterdir():
+					self.languages[language.name] = gettext.translation("mcprep", 
+											 self.languages_folder, 
+											 fallback=True,
+											 languages=[language.name])
 			self.use_direct_i18n = True
 			self.log("Loaded direct i18n!")
+
+		except Exception:
+			self.languages = {}
+			self.log("Exception occured while loading translations!")
+
 	
 	# This allows us to translate strings on the fly
 	def _(self, msg: str) -> str:


### PR DESCRIPTION
If translations.py doesn't exist, MCprep moves to direct i18n, which directly uses MO files for translations (at the cost of some UI updating issues). However, if these MO files do not exist, then MCprep will throw an exception. Since this exception occurs in the creation of `MCprepEnv`, MCprep is rendered unusable.

This patch adds a basic try-except statement to allow `MCprepEnv` to handle these exceptions gracefully.