### PR TITLE
Using updated production bab build command

### DIFF
--- a/push_latest.sh
+++ b/push_latest.sh
@@ -56,7 +56,13 @@ rm mcprep_addon_trackerid.json
 
 echo "Building prod addon..."
 bab -b translate # No --during-build dev to make it prod.
-ls build/MCprep_addon.zip
+if [ $? -eq 0 ]; then
+    echo "Build complete"
+    ls build/MCprep_addon.zip
+else
+    echo "Build failed"
+    exit
+fi
 
 # -----------------------------------------------------------------------------
 # Cross check no local changes, such as updated translations

--- a/push_latest.sh
+++ b/push_latest.sh
@@ -55,7 +55,7 @@ rm MCprep_addon/mcprep_addon_tracker.json
 rm mcprep_addon_trackerid.json
 
 echo "Building prod addon..."
-bpy-addon-build -b translate # No --during-build dev to make it prod.
+bab -b translate # No --during-build dev to make it prod.
 ls build/MCprep_addon.zip
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Appears this change fixes the building problem. Confirmed that this results in both no dev txt file and the mo files are indeed now present, where they weren't in the prior build.